### PR TITLE
docs(readme): fix Deploy to Netlify links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains a **minimal setup** of components, queries and tooling to get started with Hydrogen.
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/hydrogen-template#SESSION_SECRET=mock%20token&PUBLIC_STORE_DOMAIN=mock.shop)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/hydrogen-template)
 
 - [Check out Hydrogen docs](https://shopify.dev/custom-storefronts/hydrogen)
 - [Get familiar with Remix](https://remix.run/docs/)
@@ -33,7 +33,7 @@ We highly recommend using this template to deploy a Hydrogen site to Netlify.
 npm install -g netlify-cli@latest
 ```
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/hydrogen-template#SESSION_SECRET=mock%20token&PUBLIC_STORE_DOMAIN=mock.shop)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/hydrogen-template)
 
 To create a new project, either click the "Deploy to Netlify" button above, or run the following command:
 


### PR DESCRIPTION
We already configure this in the `netlify.toml`. These aren't quite right, so I just removed them.

Before:

![Screenshot 2024-09-05 at 16 03 04](https://github.com/user-attachments/assets/18a21f8a-0b07-422e-a97c-2e61dfbee5e7)

After:

![Screenshot 2024-09-05 at 16 08 39](https://github.com/user-attachments/assets/332192e0-2a76-4887-90c1-8afdee841677)