### PR TITLE
fix: use correct path for caching hached assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 
 # Set immutable caching for static files, because they have fingerprinted filenames
 [[headers]]
-for = "/dist/client/*"
+for = "/assets/*"
 [headers.values]
 "Cache-Control" = "public, max-age=31560000, immutable"
 


### PR DESCRIPTION
This configuring expects a _request_ path, not a build file path, so it's relative to the publish dir, not the base dir.