### PR TITLE
docs: clarify instructions in netlify.toml env template

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,5 +14,5 @@ for = "/assets/*"
 # These are only used to set up the template, and are not used in the build
 # If you want to update the real values, change them in the site UI or CLI
 [template.environment]
-PUBLIC_STORE_DOMAIN = "Store domain. Leave as 'mock.shop' to try the demo site"
-SESSION_SECRET = "Session secret - change to a random value for production"
+PUBLIC_STORE_DOMAIN = "Store domain - set this to 'mock.shop' to try the demo site"
+SESSION_SECRET = "Session secret - set this to a random value for production"


### PR DESCRIPTION
"Leave as" implies that you can leave the field untouched, but you actually need to set it to "mock.shop".

There doesn't seem to be a way to include both instructions and a default:
https://docs.netlify.com/site-deploys/create-deploys/#template-configuration.