### PR TITLE
fix: remove leftover refs to gift cards

### DIFF
--- a/app/lib/fragments.ts
+++ b/app/lib/fragments.ts
@@ -108,12 +108,6 @@ export const CART_QUERY_FRAGMENT = `#graphql
   fragment CartApiQuery on Cart {
     updatedAt
     id
-    appliedGiftCards {
-      lastCharacters
-      amountUsed {
-        ...Money
-      }
-    }
     checkoutUrl
     totalQuantity
     buyerIdentity {

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -72,11 +72,6 @@ export type CartApiQueryFragment = Pick<
   StorefrontAPI.Cart,
   'updatedAt' | 'id' | 'checkoutUrl' | 'totalQuantity' | 'note'
 > & {
-  appliedGiftCards: Array<
-    Pick<StorefrontAPI.AppliedGiftCard, 'lastCharacters'> & {
-      amountUsed: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
-    }
-  >;
   buyerIdentity: Pick<
     StorefrontAPI.CartBuyerIdentity,
     'countryCode' | 'email' | 'phone'


### PR DESCRIPTION
This results in a GraphQL warning in the console because `appliedGiftCards` is not a field on Cart.

This was my bad when pulling in the latest changes to the base Hydrogen template into this one.

I hadn't noticed because it only prints the warning when viewing the cart.